### PR TITLE
Fix wrong variables assignment

### DIFF
--- a/label_studio_tools/core/utils/io.py
+++ b/label_studio_tools/core/utils/io.py
@@ -54,7 +54,7 @@ def get_local_path(url,
 
     # File reference created with --allow-serving-local-files option
     if is_local_file:
-        filename, dir_path = url.split('/data/')[1].split('?d=')
+        dir_path, filename = url.split('/data/')[1].split('?d=')
         dir_path = str(urllib.parse.unquote(dir_path))
         filepath = os.path.join(dir_path, filename)
         if not os.path.exists(filepath):

--- a/label_studio_tools/core/utils/io.py
+++ b/label_studio_tools/core/utils/io.py
@@ -55,7 +55,7 @@ def get_local_path(url,
     # File reference created with --allow-serving-local-files option
     if is_local_file:
         dir_path, filename = url.split('/data/')[1].split('?d=')
-        dir_path = str(urllib.parse.unquote(dir_path))
+        filename = str(urllib.parse.unquote(filename))
         filepath = os.path.join(dir_path, filename)
         if not os.path.exists(filepath):
             raise FileNotFoundError(filepath)


### PR DESCRIPTION
Current output:

```python
url = "https://example.com/data/local-files/?d=path/to/image.jpg"
filename, dir_path = url.split('/data/')[1].split('?d=')
print(filename, dir_path)
dir_path = str(urllib.parse.unquote(dir_path))
filepath = os.path.join(dir_path, filename)
print(filepath)
```

> local-files/ path/to/image.jpg
> path/to/image.jpg/local-files/


Output with the pull request:

```python
url = "https://example.com/data/local-files/?d=path/to/image.jpg"
dir_path, filename = url.split('/data/')[1].split('?d=')
print(filename, dir_path)
dir_path = str(urllib.parse.unquote(dir_path))
filepath = os.path.join(dir_path, filename)
print(filepath)
```

> local-files/path/to/image.jpg
> path/to/image.jpg local-files/
