### PR TITLE
fix: Include requirements.txt in source tarball ("sdist")

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Currently if someone wants to install `label-studio-tools` using the sdist (i.e. `tar.gz` archive), the installation fails due to `requirements.txt` not being part of the source tarball. This PR fixes it.

The following error is what is currently happening:

```
Created temporary directory: /private/tmp/pip-ephem-wheel-cache-5ze3eijn
Processing $SRC_DIR
  Added file://$SRC_DIR to build tracker '/private/tmp/pip-build-tracker-lxjr_7qv'
  Running setup.py (path:$SRC_DIR/setup.py) egg_info for package from file://$SRC_DIR
  Created temporary directory: /private/tmp/pip-pip-egg-info-x9tpb5nf
  Preparing metadata (setup.py): started
  Running command python setup.py egg_info
  Traceback (most recent call last):
    File "<string>", line 2, in <module>
    File "<pip-setuptools-caller>", line 34, in <module>
    File "/Users/uwe/mambaforge/conda-bld/label-studio-tools_1670424942505/work/setup.py", line 11, in <module>
      with open(requirements_file, 'r') as f:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: '/Users/uwe/mambaforge/conda-bld/label-studio-tools_1670424942505/work/requirements.txt'
  error: subprocess-exited-with-error
```